### PR TITLE
Fix: code quality issues in MCP tool and service registration

### DIFF
--- a/Iris-core/src/main/java/io/github/qylh/iris/core/mqtt/PahoMqttClient.java
+++ b/Iris-core/src/main/java/io/github/qylh/iris/core/mqtt/PahoMqttClient.java
@@ -31,8 +31,12 @@ import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PahoMqttClient extends MqttClient {
+    
+    private static final Logger log = LoggerFactory.getLogger(PahoMqttClient.class);
     
     private org.eclipse.paho.client.mqttv3.MqttClient mqttClient;
     
@@ -65,7 +69,7 @@ public class PahoMqttClient extends MqttClient {
     public void publish(String topic, MqttMsg message) throws MqttClientException {
         message.setClientId(this.mqttClient.getClientId());
         try {
-            System.out.println("publish topic:" + topic);
+            log.debug("publish topic: {}", topic);
             this.mqttClient.publish(topic, message.toPahoMqttMessage());
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
             throw new MqttClientException(e.getMessage());
@@ -110,7 +114,7 @@ public class PahoMqttClient extends MqttClient {
             IMqttMessageListener iMqttMessageListener = (topic1, message) -> mqttMsgListener.onMessage(topic1, MqttRequest.fromPahoMqttMessage((MqttMessage) message));
             this.mqttClient.subscribe(topic, 2, iMqttMessageListener);
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -121,7 +125,7 @@ public class PahoMqttClient extends MqttClient {
             try {
                 this.mqttClient.subscribe(t, iMqttMessageListener);
             } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-                e.printStackTrace();
+                log.error("MQTT client error", e);
             }
         }
     }
@@ -132,7 +136,7 @@ public class PahoMqttClient extends MqttClient {
             IMqttMessageListener iMqttMessageListener = (topic1, message) -> mqttMsgListener.onMessage(topic1, MqttResponse.fromPahoMqttMessage((MqttMessage) message));
             this.mqttClient.subscribe(topic, iMqttMessageListener);
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -143,7 +147,7 @@ public class PahoMqttClient extends MqttClient {
             try {
                 this.mqttClient.subscribe(t, iMqttMessageListener);
             } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-                e.printStackTrace();
+                log.error("MQTT client error", e);
             }
         }
     }
@@ -154,7 +158,7 @@ public class PahoMqttClient extends MqttClient {
             IMqttMessageListener iMqttMessageListener = (topic1, message) -> mqttMsgListener.onMessage(topic1, MqttRegisterMsg.fromPahoMqttMessage((MqttMessage) message));
             this.mqttClient.subscribe(topic, iMqttMessageListener);
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -164,7 +168,7 @@ public class PahoMqttClient extends MqttClient {
             IMqttMessageListener iMqttMessageListener = (topic1, message) -> payLoadListener.onMessage(topic1, new String(message.getPayload()));
             this.mqttClient.subscribe(topic, iMqttMessageListener);
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -173,7 +177,7 @@ public class PahoMqttClient extends MqttClient {
         try {
             this.mqttClient.unsubscribe(topic);
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -183,7 +187,7 @@ public class PahoMqttClient extends MqttClient {
             try {
                 this.mqttClient.unsubscribe(t);
             } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-                e.printStackTrace();
+                log.error("MQTT client error", e);
             }
         }
     }
@@ -193,7 +197,7 @@ public class PahoMqttClient extends MqttClient {
         try {
             this.mqttClient.disconnect();
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     
@@ -207,7 +211,7 @@ public class PahoMqttClient extends MqttClient {
         try {
             this.mqttClient.publish(topic, msg.toPahoMqttMessage());
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
-            e.printStackTrace();
+            log.error("MQTT client error", e);
         }
     }
     

--- a/Iris-core/src/main/java/io/github/qylh/iris/core/server/RequestProcessor.java
+++ b/Iris-core/src/main/java/io/github/qylh/iris/core/server/RequestProcessor.java
@@ -89,39 +89,33 @@ public class RequestProcessor {
                     continue;
                 }
                 for (Method method : methods) {
-                    if (method.isAnnotationPresent(IrisApi.class) || method.getDeclaringClass() == Object.class) {
-                        String apiName;
-                        if (method.getDeclaringClass() == Object.class) {
-                            apiName = method.getName();
-                        } else {
-                            apiName = method.getAnnotation(IrisApi.class).name();
-                            if (method.isAnnotationPresent(IrisTool.class)) {
-                                String registerTopic = Constants.MQTT_REGISTER_TOPIC_SUFFIX + serviceName + "/" + apiName;
-                                MqttRegisterMsg registerMsg = new MqttRegisterMsg();
-                                registerMsg.setQos(2);
-                                registerMsg.setServiceName(serviceName);
-                                registerMsg.setMethodName(method.getName());
-                                registerMsg.setServiceDesc(service.getAnnotation(IrisService.class).desc());
-                                registerMsg.setMethodName(method.getName());
-                                registerMsg.setMethodDesc(method.getAnnotation(IrisTool.class).desc());
-                                // todo 必须把实现的接口放到第一个
-                                registerMsg.setInterfaceType(service.getInterfaces()[0]);
-                                Parameter[] parameters = method.getParameters();
-                                registerMsg.setArgsType(method.getParameterTypes());
-                                registerMsg.setArgsDesc(Stream.of(parameters).map(
-                                        parameter -> {
-                                            if (parameter.isAnnotationPresent(IrisToolParam.class)) {
-                                                return parameter.getAnnotation(IrisToolParam.class).desc();
-                                            } else {
-                                                return "";
-                                            }
-                                        }).toArray(String[]::new));
-                                // 保留消息注册
-                                mqttClient.register(registerTopic, registerMsg);
-                            }
+                    if (method.isAnnotationPresent(IrisApi.class)) {
+                        String apiName = method.getAnnotation(IrisApi.class).name();
+                        if (method.isAnnotationPresent(IrisTool.class)) {
+                            String registerTopic = Constants.MQTT_REGISTER_TOPIC_SUFFIX + serviceName + "/" + apiName;
+                            MqttRegisterMsg registerMsg = new MqttRegisterMsg();
+                            registerMsg.setQos(2);
+                            registerMsg.setServiceName(serviceName);
+                            registerMsg.setMethodName(method.getName());
+                            registerMsg.setServiceDesc(service.getAnnotation(IrisService.class).desc());
+                            registerMsg.setMethodDesc(method.getAnnotation(IrisTool.class).desc());
+                            // todo 必须把实现的接口放到第一个
+                            registerMsg.setInterfaceType(service.getInterfaces()[0]);
+                            Parameter[] parameters = method.getParameters();
+                            registerMsg.setArgsType(method.getParameterTypes());
+                            registerMsg.setArgsDesc(Stream.of(parameters).map(
+                                    parameter -> {
+                                        if (parameter.isAnnotationPresent(IrisToolParam.class)) {
+                                            return parameter.getAnnotation(IrisToolParam.class).desc();
+                                        } else {
+                                            return "";
+                                        }
+                                    }).toArray(String[]::new));
+                            // 保留消息注册
+                            mqttClient.register(registerTopic, registerMsg);
                         }
                         String fullName = Constants.MQTT_REQUEST_TOPIC_SUFFIX + serviceName + "/" + apiName;
-                        System.out.println(fullName);
+                        Log.debug("Subscribe request topic: {}", fullName);
                         mqttClient.subscribe_request(fullName, (topic, message) -> {
                             MqttResponse mqttResponse = new MqttResponse();
                             MqttRequest mqttRequest = (MqttRequest) message;
@@ -138,7 +132,7 @@ public class RequestProcessor {
                                 mqttResponse.setMsg("Failed to invoke method :" + fullName);
                             } finally {
                                 try {
-                                    System.out.println(mqttResponse);
+                                    Log.debug("Response: {}", mqttResponse);
                                     mqttClient.publish(Constants.MQTT_RESPONSE_TOPIC_SUFFIX + message.getClientId(), mqttResponse);
                                 } catch (MqttClientException e) {
                                     Log.error("Failed to publish response" + e.getMessage());

--- a/Iris-example/example-mcp-client-spring/src/main/java/io/github/qylh/example/mcp/client/spring/ChatClientConfig.java
+++ b/Iris-example/example-mcp-client-spring/src/main/java/io/github/qylh/example/mcp/client/spring/ChatClientConfig.java
@@ -18,31 +18,21 @@
  */
 package io.github.qylh.example.mcp.client.spring;
 
-import io.modelcontextprotocol.client.McpSyncClient;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @Configuration
 public class ChatClientConfig {
-    
-    @Autowired
-    private List<McpSyncClient> mcpSyncClients;
     
     @Autowired
     ToolCallbackProvider tools;
     
     @Bean
     public ChatClient chatClient(OpenAiChatModel chatModel) {
-        for (ToolCallback toolCallback : tools.getToolCallbacks()) {
-            System.out.println(toolCallback.getToolDefinition());
-        }
         return ChatClient.builder(chatModel).defaultToolCallbacks(tools).build();
     }
 }

--- a/Iris-spring-boot-starter/src/main/java/io/github/qylh/iris/spring/boot/IrisMCPToolRegister.java
+++ b/Iris-spring-boot-starter/src/main/java/io/github/qylh/iris/spring/boot/IrisMCPToolRegister.java
@@ -29,11 +29,14 @@ import io.github.qylh.iris.core.mqtt.PahoMqttClient;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
+import javax.annotation.PostConstruct;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -46,6 +49,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class IrisMCPToolRegister implements ApplicationContextAware {
     
+    private static final Logger log = LoggerFactory.getLogger(IrisMCPToolRegister.class);
+    
     private ApplicationContext applicationContext;
     
     private static Map<String, McpServerFeatures.SyncToolSpecification> syncToolSpecifications = new ConcurrentHashMap<>();
@@ -54,7 +59,7 @@ public class IrisMCPToolRegister implements ApplicationContextAware {
     
     private final ClientProxyFactory clientProxyFactory;
     
-    @Autowired
+    @Autowired(required = false)
     private McpSyncServer mcpSyncServer;
     
     public IrisMCPToolRegister(IrisProperties properties, ClientProxyFactory clientProxyFactory) throws MqttClientException {
@@ -74,6 +79,10 @@ public class IrisMCPToolRegister implements ApplicationContextAware {
             throw new RuntimeException("mqtt client connect error", e);
         }
         this.clientProxyFactory = clientProxyFactory;
+    }
+    
+    @PostConstruct
+    public void init() {
         startListen();
     }
     
@@ -90,21 +99,31 @@ public class IrisMCPToolRegister implements ApplicationContextAware {
     }
     
     private void buildSyncToolSpecification(MqttRegisterMsg msg) throws NoSuchMethodException {
+        if (mcpSyncServer == null) {
+            log.warn("McpSyncServer not available, skip tool registration for: {}", msg.getServiceName());
+            return;
+        }
         String serviceName = msg.getServiceName();
         Class<?> interfaceType = msg.getInterfaceType();
         Object serviceProxy = clientProxyFactory.getProxy(interfaceType);
-        // Object serviceProxy = applicationContext.getBean(serviceName);
-        Method method = serviceProxy.getClass().getMethod(msg.getMethodName());
+        Class<?>[] argTypes = msg.getArgsType();
+        Method method = interfaceType.getMethod(msg.getMethodName(), argTypes);
         // 构造 tool
         String toolName = serviceName + "-" + msg.getMethodName();
         String toolDesc = msg.getServiceDesc() + msg.getMethodDesc();
         Map<String, Object> properties = new HashMap<>();
         List<String> required = new ArrayList<>();
-        for (int i = 0; i < msg.getArgsType().length; i++) {
+        Parameter[] parameters = method.getParameters();
+        for (int i = 0; i < parameters.length; i++) {
             Map<String, Object> param = new HashMap<>();
-            param.put("type", msg.getArgsType()[i].getSimpleName());
-            param.put("desc", msg.getArgsDesc()[i]);
-            properties.put(method.getParameters()[i].getName(), param);
+            param.put("type", toJsonType(argTypes[i]));
+            param.put("description", msg.getArgsDesc()[i]);
+            // 使用参数名（需 -parameters 编译），降级为 param_{i}
+            String paramName = parameters[i].getName();
+            if (paramName.startsWith("arg")) {
+                paramName = "param" + i;
+            }
+            properties.put(paramName, param);
             required.add("true");
         }
         McpSchema.JsonSchema toolSchema = new McpSchema.JsonSchema(
@@ -116,10 +135,13 @@ public class IrisMCPToolRegister implements ApplicationContextAware {
         McpServerFeatures.SyncToolSpecification syncToolSpecification = new McpServerFeatures.SyncToolSpecification(
                 Tool,
                 (exchange, arguments) -> {
-                    Parameter[] methodParameters = method.getParameters();
-                    Object[] args = new Object[methodParameters.length];
-                    for (int i = 0; i < methodParameters.length; i++) {
-                        args[i] = arguments.get(methodParameters[i].getName());
+                    Object[] args = new Object[parameters.length];
+                    for (int i = 0; i < parameters.length; i++) {
+                        String key = parameters[i].getName();
+                        if (key.startsWith("arg")) {
+                            key = "param" + i;
+                        }
+                        args[i] = arguments.get(key);
                     }
                     try {
                         Object res = method.invoke(serviceProxy, args);
@@ -136,6 +158,21 @@ public class IrisMCPToolRegister implements ApplicationContextAware {
     
     private Map<String, McpServerFeatures.SyncToolSpecification> getSyncToolSpecifications() {
         return syncToolSpecifications;
+    }
+    
+    private static String toJsonType(Class<?> javaType) {
+        if (javaType == Boolean.class || javaType == boolean.class) {
+            return "boolean";
+        } else if (javaType == Integer.class || javaType == int.class
+                || javaType == Long.class || javaType == long.class) {
+            return "integer";
+        } else if (javaType == Double.class || javaType == double.class
+                || javaType == Float.class || javaType == float.class) {
+            return "number";
+        } else if (javaType == String.class) {
+            return "string";
+        }
+        return "string";
     }
     
     @Override


### PR DESCRIPTION
## Summary

Code quality fixes based on review of PR #15 implementation, addressing issues in MCP tool registration and service registration.

Closes #19

## Changes

### Critical
- **RequestProcessor**: Remove `method.getDeclaringClass() == Object.class` condition that caused toString/equals/hashCode to be registered as RPC handlers
- **IrisMCPToolRegister**: Fix parameter name fallback (use param_{i} when -parameters flag missing)
- **IrisMCPToolRegister**: Map Java types to JSON Schema types (Integer → integer, String → string, etc.)
- **IrisMCPToolRegister**: Move startListen() to @PostConstruct to ensure mcpSyncServer injection
- **IrisMCPToolRegister**: Add null-safe mcpSyncServer handling for client-only scenarios

### Minor
- **PahoMqttClient**: Replace e.printStackTrace() with SLF4J Logger (10 occurrences)
- **RequestProcessor**: Replace System.out.println with Logger
- **ChatClientConfig**: Remove debug output and unused imports

## Test plan

- [x] `mvn clean test` passes (BUILD SUCCESS)
- [ ] CI pipeline runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)